### PR TITLE
Update db to Hetzner db and start db API

### DIFF
--- a/API.md
+++ b/API.md
@@ -79,9 +79,9 @@ Method: **POST**
 
 Parameters:
 
-- `trip_id`: (Optional) The unique trip ID. If left empty, a new trip
-  will be created in the database, with the authenticated user as the
-  owner.
+- `trip_id`: (Optional) The unique and valid trip ID. If left empty, a
+  new trip will be created in the database, with the authenticated
+  user as the owner.
 - `view`: (Optional) The emails of the users (besides owner) who can
   access the trip to *view*.
 - `edit`: (Optional) The emails of the users (besides owner) who can
@@ -119,7 +119,7 @@ or _viewer_ but not _owner_).
 
 #### `api/private/get_trip?trip_id={id}`
 
-Method: **GET**
+Method: **POST**
 
 Parameters:
 

--- a/API.md
+++ b/API.md
@@ -13,6 +13,8 @@ Frontend URLS:
 - [prod](https://dayscape.netlify.app/) 
 - [dev](https://dayscape-dev.netlify.app/)
 
+Furthermore, good usage documentation is in `src/tests/api_tests.js` in the frontend repository.
+
 ## Authentication
 
 Read the [Auth0 documentation](https://auth0.com/docs/quickstart/backend/python/02-using) first. There is also a more

--- a/API.md
+++ b/API.md
@@ -73,7 +73,7 @@ Parameters:
 
 Returns the Maps API Key for the frontend to use.
 
-#### `api/private/save_trip?trip_id={id}&view={users}&edit={users}`
+#### `api/private/save_trip?trip_id={id}&trip_name={name}&view={users}&edit={users}`
 
 Method: **POST**
 
@@ -82,6 +82,8 @@ Parameters:
 - `trip_id`: (Optional) The unique and valid trip ID. If left empty, a
   new trip will be created in the database, with the authenticated
   user as the owner.
+- `trip_name`: (Optional) Trip name. If left empty, the old name will
+  be kept
 - `view`: (Optional) The emails of the users (besides owner) who can
   access the trip to *view*.
 - `edit`: (Optional) The emails of the users (besides owner) who can

--- a/API.md
+++ b/API.md
@@ -48,6 +48,21 @@ These endpoints will be used by anyone **without** an account.
 
 These endpoints will be used by anyone **with** an account.
 
+#### `api/public/preferences_to_types`
+
+Method: **POST**
+Parameters:
+- `input_list`: List of preference strings
+
+Returns a JSON list of [Google Places API
+"Types"](https://developers.google.com/maps/documentation/places/web-service/supported_types). The
+AI could hallucinate, so the output should be checked against a list
+of valid types.
+
+Mostly a demo method to test the LLM and explore deeper API
+integration from the frontend.
+
+
 #### `api/private/maps_key`
 
 Method: **GET**
@@ -113,16 +128,21 @@ Parameters:
 Returns the JSON trip structure if the authenticated user has
 permissions to view the trip.
 
-#### `api/private/preferences_to_types`
+#### `api/private/get_preferences`
+
+Method: **GET**
+
+Parameters: none
+
+Returns the JSON preferences stored in the db for the authenticated user.
+
+#### `api/private/save_preferences`
 
 Method: **POST**
-Parameters:
-- `input_list`: List of preference strings
 
-Returns a JSON list of [Google Places API
-"Types"](https://developers.google.com/maps/documentation/places/web-service/supported_types). The
-AI could hallucinate, so the output should be checked against a list
-of valid types.
+Parameters: none
 
-Mostly a demo method to test the LLM and explore deeper API
-integration from the frontend.
+Updates the JSON preferences stored in the db for the authenticated
+user from the body of the request. The entire json body of the request
+will be stored.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3-alpine
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
@@ -26,8 +26,12 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 COPY . ./
 
-# Install production dependencies.
-RUN pip install --no-cache-dir -r requirements.txt
+# install/build project
+RUN \
+    apk add --no-cache postgresql-libs && \
+    apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
+    pip install --no-cache-dir -r requirements.txt  && \
+    apk --purge del .build-deps
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/app.py
+++ b/app.py
@@ -162,26 +162,16 @@ def maps_api_key():
     key = google_secrets.get_secret("maps_api_key")
     return jsonify(message=key)
 
-# STUB
 # Returns a list of trip IDs and names for
 # trips owned by the authenticated user.
 @APP.route("/api/private/get_owned_trips_list")
 @requires_auth
 def get_owned_trips_list():
-
-    # TODO:
-    # - get Auth0 user
-    # - Query database for owned trips
-
-    # list of trip IDs/names to be displayed on profile page
-    example_trips = {
-        "60f62fed-df59-4ad0-8e73-677e3fda5d9a": "Summer Family Beach Trip",
-        "1336c22f-b80c-4b39-9528-a2bfded82e29": "My mountain trip",
-        "936ba739-db01-45c8-ba46-38ec8acc21f7": "London 2026",
-        "51c28468-0930-4fcf-b8a7-3c2d58e9ac27": "Example trip name",
-    }
-    data = jsonify(example_trips)
-    return jsonify(data.json)
+    email = request_ctx.user_info.get("email")
+    trips = database.db_get_owned_trips(email)
+    objects = [{"uuid": str(uuid), "name": name if name is not None else ""} for uuid, name in trips]
+    data = jsonify(objects)
+    return data.json
 
 # STUB
 # Returns a list of trip IDs and names for trips that have been shared
@@ -189,19 +179,11 @@ def get_owned_trips_list():
 @APP.route("/api/private/get_shared_trips_list")
 @requires_auth
 def get_shared_trips_list():
-    # TODO:
-    # - get Auth0 user
-    # - Query database for trips where user is viewer or editor (not owner)
-
-    # list of trip IDs/names to be displayed on profile page ("Shared with me")
-    example_trips = {
-        "60f62fed-df59-4ad0-8e73-677e3fda5d9a": "Shared Hiking Trip",
-        "1336c22f-b80c-4b39-9528-a2bfded82e29": "Corrie's Wedding Trip",
-        "936ba739-db01-45c8-ba46-38ec8acc21f7": "Night City 2077",
-        "51c28468-0930-4fcf-b8a7-3c2d58e9ac27": "Example shared trip name",
-    }
-    data = jsonify(example_trips)
-    return jsonify(data.json)
+    email = request_ctx.user_info.get("email")
+    trips = database.db_get_shared_trips(email)
+    objects = [{"uuid": str(uuid), "name": name if name is not None else ""} for uuid, name in trips]
+    data = jsonify(objects)
+    return data.json
 
 from llm import match_to_places_api_types
 # Returns a list of google map "types" based on the preference tag

--- a/app.py
+++ b/app.py
@@ -207,17 +207,19 @@ def call_userinfo_endpoint(token):
     return response.json()
 
 # Saves the trip data to the database, optionally modifying trip
-# permissions. Creates a new trip if no trip_id is supplied
+# permissions. Creates a new trip if no trip_id is supplied. Returns
+# trip_id.
 @APP.route("/api/private/save_trip", methods=['POST'])
 @requires_auth
 def save_trip():
     email = request_ctx.user_info.get("email")
-    trip_data = request.json
     trip_id = request.args.get('trip_id', None)
+    trip_name = request.args.get('trip_name', None)
+    trip_data = request.json
     view = request.args.get('view', None)
     edit = request.args.get('edit', None)
-    database.db_save_trip(email, trip_id, trip_data, view, edit)
-    return "saved trip"
+    id = database.db_save_trip(email, trip_id, trip_name, trip_data, view, edit)
+    return str(id)
 
 # Returns the JSON trip structure if the authenticated user has
 # permissions to view the trip.
@@ -235,6 +237,8 @@ def get_trip():
 def get_preferences():
     email = request_ctx.user_info.get("email")
     data = jsonify(database.db_get_preferences(email))
+    print("data")
+    print(data)
     return (data.json)
 
 # saves the JSON body of the request as user preferences in the db

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ auth0_audience = os.environ.get("AUTH0_AUDIENCE", DEV_URL if environment == "dev
 # same pg instance called dayscape-dev
 db_connector = "moonlit-mesh-437320-t8:us-east1:dayscape-dev"
 # Database name
-db_name = "dayscape-dev-db" if environment == "dev" else "dayscape-prod-db"
+db_name = "dayscape-dev" if environment == "dev" else "dayscape-prod"
 
 # Deployments on Cloud Run must change the following variables to
 # match the corresponding frontend deployment URL

--- a/database.py
+++ b/database.py
@@ -88,8 +88,9 @@ def db_save_trip(authenticated_user, trip_id=None, trip_data=None, view=None, ed
         if not trip and trip_id:
           raise PermissionError("Invalid trip ID")
 
-        # Owner can update editors and viewers
+        # Owner can update name, editors, and viewers
         if trip.owner == authenticated_user:
+            trip.name = trip_name if trip_name is not None else trip.name
             trip.viewers = view if view is not None else trip.viewers
             trip.editors = edit if edit is not None else trip.editors
             trip.trip_data = trip_data if trip_data is not None else trip.trip_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ six
 gunicorn
 google-cloud-secret-manager
 openai
-cloud-sql-python-connector[asyncpg]
 sqlalchemy
-pg8000
+psycopg2

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,16 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp"; -- For generating UUIDs
+-- Create user and set (fake) password
+CREATE USER dayscape WITH PASSWORD 'password';
+
+-- Create dayscape-dev database and switch to it. All commands after
+-- this line will be repeated for 'dayscape-prod' db
+CREATE DATABASE "dayscape-dev";
+\c "dayscape-dev"
+
+-- Example command to connect to this db:
+-- PGPASSWORD=<password> psql -h <IP> -U dayscape -d dayscape-dev
+
+-- For generating UUIDs
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE trip (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -21,12 +33,5 @@ ALTER TABLE preference
 ADD CONSTRAINT check_preferences_data_size
 CHECK (octet_length(preferences_data::text) <= 2048);
 
-GRANT INSERT, UPDATE, DELETE ON trip TO "dayscape-backend@moonlit-mesh-437320-t8.iam";
-GRANT INSERT, UPDATE, DELETE ON preference TO "dayscape-backend@moonlit-mesh-437320-t8.iam";
-
--- The following will fail because of constraint on preference size
--- INSERT INTO preference (email, preferences_data)
--- VALUES (
---     'test@example.com',
---     ('{ "key": "' || repeat('a', 2049) || '"}')::jsonb
--- );
+GRANT SELECT, INSERT, UPDATE, DELETE ON trip TO "dayscape";
+GRANT SELECT, INSERT, UPDATE, DELETE ON preference TO "dayscape";


### PR DESCRIPTION
- using new DB hosted on a fedora server with Hetzner
- API to save and retrieve global user preferences implemented and manually tested
- switch to alpine based container (needed to build psycopg dependency)
- `/api/public/preferences_to_types` is now public and does not require authentication
- get_trip and save_trip are implemented and end-to-end tested
- get_owned/shared_trips_list are implemented and manually tested

End-to-end tests are in https://github.com/Capstone-DayScape/dayscape-frontend/pull/27